### PR TITLE
Default sim spoof to Latvia and spoof SIM presence

### DIFF
--- a/revanced-patches/extensions/tiktok/src/main/java/app/revanced/extension/tiktok/settings/Settings.java
+++ b/revanced-patches/extensions/tiktok/src/main/java/app/revanced/extension/tiktok/settings/Settings.java
@@ -21,7 +21,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting CLEAR_DISPLAY = new BooleanSetting("clear_display", FALSE);
     public static final FloatSetting REMEMBERED_SPEED = new FloatSetting("REMEMBERED_SPEED", 1.0f);
     public static final BooleanSetting SIM_SPOOF = new BooleanSetting("simspoof", TRUE, true);
-    public static final StringSetting SIM_SPOOF_ISO = new StringSetting("simspoof_iso", "us");
-    public static final StringSetting SIMSPOOF_MCCMNC = new StringSetting("simspoof_mccmnc", "310160");
-    public static final StringSetting SIMSPOOF_OP_NAME = new StringSetting("simspoof_op_name", "T-Mobile");
+    public static final StringSetting SIM_SPOOF_ISO = new StringSetting("simspoof_iso", "lv");
+    public static final StringSetting SIMSPOOF_MCCMNC = new StringSetting("simspoof_mccmnc", "24701");
+    public static final StringSetting SIMSPOOF_OP_NAME = new StringSetting("simspoof_op_name", "LMT");
 }

--- a/revanced-patches/extensions/tiktok/src/main/java/app/revanced/extension/tiktok/spoof/sim/SpoofSimPatch.java
+++ b/revanced-patches/extensions/tiktok/src/main/java/app/revanced/extension/tiktok/spoof/sim/SpoofSimPatch.java
@@ -8,6 +8,12 @@ import app.revanced.extension.tiktok.settings.Settings;
 public class SpoofSimPatch {
 
     /**
+     * {@link android.telephony.TelephonyManager#SIM_STATE_READY}.
+     * Hardcoded to avoid a framework import in the extension.
+     */
+    private static final int SIM_STATE_READY = 5;
+
+    /**
      * During app startup native code can be called with no obvious way to set the context.
      * Cannot check if sim spoofing is enabled or the app will crash since no context is set.
      */
@@ -51,6 +57,32 @@ public class SpoofSimPatch {
             String operator = Settings.SIMSPOOF_OP_NAME.get();
             Logger.printDebug(() -> "Spoofing sim operatorName from: " + value + " to: " + operator);
             return operator;
+        }
+
+        return value;
+    }
+
+    /**
+     * Make a SIM-less device report a present, ready SIM so the spoofed operator/country
+     * stays consistent (TikTok checks the SIM state alongside the operator info).
+     */
+    public static int getSimState(int value) {
+        if (isContextNotSet("simState")) return value;
+
+        if (Settings.SIM_SPOOF.get()) {
+            Logger.printDebug(() -> "Spoofing simState from: " + value + " to: " + SIM_STATE_READY);
+            return SIM_STATE_READY;
+        }
+
+        return value;
+    }
+
+    public static boolean hasIccCard(boolean value) {
+        if (isContextNotSet("hasIccCard")) return value;
+
+        if (Settings.SIM_SPOOF.get()) {
+            Logger.printDebug(() -> "Spoofing hasIccCard from: " + value + " to: true");
+            return true;
         }
 
         return value;

--- a/revanced-patches/patches/src/main/kotlin/app/revanced/patches/tiktok/misc/spoof/sim/SpoofSimPatch.kt
+++ b/revanced-patches/patches/src/main/kotlin/app/revanced/patches/tiktok/misc/spoof/sim/SpoofSimPatch.kt
@@ -30,13 +30,19 @@ val sIMSpoofPatch = bytecodePatch(
     )
 
     apply {
+        // TelephonyManager method name -> Triple(extension method, smali type, isReferenceType).
+        // The smali type is used both for the parameter and the return value; isReferenceType
+        // picks move-result-object (true) vs move-result (false).
         val replacements = hashMapOf(
-            "getSimCountryIso" to "getCountryIso",
-            "getNetworkCountryIso" to "getCountryIso",
-            "getSimOperator" to "getOperator",
-            "getNetworkOperator" to "getOperator",
-            "getSimOperatorName" to "getOperatorName",
-            "getNetworkOperatorName" to "getOperatorName",
+            "getSimCountryIso" to Triple("getCountryIso", "Ljava/lang/String;", true),
+            "getNetworkCountryIso" to Triple("getCountryIso", "Ljava/lang/String;", true),
+            "getSimOperator" to Triple("getOperator", "Ljava/lang/String;", true),
+            "getNetworkOperator" to Triple("getOperator", "Ljava/lang/String;", true),
+            "getSimOperatorName" to Triple("getOperatorName", "Ljava/lang/String;", true),
+            "getNetworkOperatorName" to Triple("getOperatorName", "Ljava/lang/String;", true),
+            // Make a SIM-less device look like it has a ready SIM, so the spoofed operator stays consistent.
+            "getSimState" to Triple("getSimState", "I", false),
+            "hasIccCard" to Triple("hasIccCard", "Z", false),
         )
 
         // Find all api call to check sim information.
@@ -46,7 +52,7 @@ val sIMSpoofPatch = bytecodePatch(
                     buildMap methodList@{
                         methods.forEach methods@{ method ->
                             with(method.implementation?.instructions ?: return@methods) {
-                                ArrayDeque<Pair<Int, String>>().also { patchIndices ->
+                                ArrayDeque<Pair<Int, Triple<String, String, Boolean>>>().also { patchIndices ->
                                     this.forEachIndexed { index, instruction ->
                                         if (instruction.opcode != Opcode.INVOKE_VIRTUAL) return@forEachIndexed
 
@@ -72,16 +78,18 @@ val sIMSpoofPatch = bytecodePatch(
             methods.forEach { (method, patches) ->
                 with(classDef.firstMethod(method)) {
                     while (!patches.isEmpty()) {
-                        val (index, replacement) = patches.removeLast()
+                        val (index, target) = patches.removeLast()
+                        val (extensionMethod, descriptor, isReferenceType) = target
 
                         val resultReg = getInstruction<OneRegisterInstruction>(index + 1).registerA
+                        val moveResult = if (isReferenceType) "move-result-object" else "move-result"
 
                         // Patch Android API and return fake sim information.
                         addInstructions(
                             index + 2,
                             """
-                                invoke-static {v$resultReg}, Lapp/revanced/extension/tiktok/spoof/sim/SpoofSimPatch;->$replacement(Ljava/lang/String;)Ljava/lang/String;
-                                move-result-object v$resultReg
+                                invoke-static {v$resultReg}, Lapp/revanced/extension/tiktok/spoof/sim/SpoofSimPatch;->$extensionMethod($descriptor)$descriptor
+                                $moveResult v$resultReg
                             """,
                         )
                     }


### PR DESCRIPTION
Update TikTok extension sim-spoof defaults and add SIM presence/state spoofing.

- Settings: change default SIM spoof values from US/T-Mobile/310160 to Latvia (iso "lv", mccmnc "24701", operator "LMT").
- Java extension: add SIM_STATE_READY constant and two new helpers (getSimState, hasIccCard) to force a ready/present SIM when SIM_SPOOF is enabled; include debug logging and avoid framework import by hardcoding the constant.
- Kotlin patch: extend the replacement map to include method descriptor and return-type info (Triple<method, descriptor, isReferenceType>), add mappings for getSimState and hasIccCard, and adjust bytecode patching to use the correct invoke signature and move-result vs move-result-object handling.

These changes ensure that on SIM-less devices the spoofed operator/country remain consistent by reporting a present, ready SIM and correctly patching methods with appropriate smali types.