### PR TITLE
Fix: prevent selection of split APK for base APK

### DIFF
--- a/.github/workflows/tiktok-patcher.yml
+++ b/.github/workflows/tiktok-patcher.yml
@@ -201,9 +201,21 @@ jobs:
 
           find_base_apk() {
             DOWNLOAD_DIR="$1"
+            PACKAGE_NAME="$2"
+          
+            if [ -n "$PACKAGE_NAME" ] && [ -f "$DOWNLOAD_DIR/$PACKAGE_NAME.apk" ]; then
+              echo "$DOWNLOAD_DIR/$PACKAGE_NAME.apk"
+              return 0
+            elif [ -f "$DOWNLOAD_DIR/base.apk" ]; then
+              echo "$DOWNLOAD_DIR/base.apk"
+              return 0
+            fi
+          
             find "$DOWNLOAD_DIR" -maxdepth 1 -type f -name "*.apk" \
               ! -name "*-asset.apk" \
-              ! -name "*-df_*.apk" \
+              ! -name "*df_*.apk" \
+              ! -name "config.*.apk" \
+              ! -name "split_*.apk" \
               -exec ls -S {} + 2>/dev/null | head -n 1 || true
           }
 
@@ -300,7 +312,7 @@ jobs:
             fi
 
             # Base APK is the largest APK file in the download directory (not a split/config APK).
-            BASE_APK=$(find_base_apk "$DOWNLOAD_DIR")
+            BASE_APK=$(find_base_apk "$DOWNLOAD_DIR" "$PACKAGE_NAME")
 
             if [ -z "$BASE_APK" ]; then
               echo "Base APK not found for $PACKAGE_NAME!"


### PR DESCRIPTION
## Description
This PR fixes an issue where the patched APK fails to install. The issue is caused by the automation script incorrectly selecting a dynamic feature split APK as the base APK.

## Root Cause
In recent versions of TikTok, the dynamic feature split `df_a_dex.apk` (~74MB) can be larger than the base APK shell. 
<img width="784" height="189" alt="image" src="https://github.com/user-attachments/assets/9ed4c555-cb95-485e-951e-e0f1344d5727" />
The current `find_base_apk` function relies on file size sorting (`ls -S`) and uses the filter `! -name "*-df_*.apk"`. Because the split APK is named `df_a_dex.apk` (missing the leading hyphen), it bypasses the current filter. As a result, the script patches the split APK instead of the base APK, producing a corrupted package without a proper `AndroidManifest.xml`.

## Proposed Changes
This PR introduces a more robust, two-step fallback mechanism to select the correct base APK:

1. **Exact Name Matching (Primary Strategy):** 
   Modified `download_variant` to pass `$PACKAGE_NAME` to the `find_base_apk` function. The script now explicitly looks for `$PACKAGE_NAME.apk` (e.g., `com.zhiliaoapp.musically.apk`) or `base.apk` first.
2. **Stricter Fallback Filters:** 
   If exact matching fails, it falls back to the size-sorting method but with enhanced exclusion rules. The filter `! -name "*-df_*.apk"` has been broadened to `! -name "*df_*.apk"`, and common split patterns like `config.*.apk` and `split_*.apk` have been added to prevent future false positives.

## Impact
- Ensures the ReVanced patcher always targets the correct base APK.
- Resolves the parsing error (`could not fetch package info`) during installation.
- Improves the script's compatibility with different downloading tools and AAB split structures.